### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # @b12/website-generator-mcp-server
 B12's model context protocol server for generating websites with AI
 
+<a href="https://glama.ai/mcp/servers/@b12io/website-generator-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@b12io/website-generator-mcp-server/badge" alt="Website Generator MCP server" />
+</a>
+
 ## Usage with Claude Desktop
 
 ### Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [Website Generator](https://glama.ai/mcp/servers/@b12io/website-generator-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@b12io/website-generator-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@b12io/website-generator-mcp-server/badge" alt="Website Generator MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.